### PR TITLE
Update massCureWounds.js

### DIFF
--- a/scripts/macros/spells/massCureWounds.js
+++ b/scripts/macros/spells/massCureWounds.js
@@ -8,7 +8,8 @@ export async function massCureWounds({speaker, actor, token, character, item, ar
         if (i.document.disposition === sourceDisposition) targetTokens.push(i);
     }
     if (!targetTokens.length) return;
-    let damageFormula = workflow.castData.castLevel + 'd8[healing] + ' + chris.getSpellMod(workflow.item);
+    let diceNumber = workflow.castData.castLevel - 2;
+    let damageFormula = diceNumber + 'd8[healing] + ' + chris.getSpellMod(workflow.item);
     let damageRoll = await new Roll(damageFormula).roll({'async': true});
     if (targetTokens.length <= 6) {
         await chris.applyWorkflowDamage(workflow.token, damageRoll, 'healing', targetTokens, workflow.item.name, workflow.itemCardId);


### PR DESCRIPTION
Mass Cure Wounds is a 5th-level spell that starts at 3d8 and increases by 1d8 per spell level, so it should be level - 2 rather than just level.